### PR TITLE
Update renderable_tile_map.dart

### DIFF
--- a/packages/flame_tiled/lib/src/renderable_tile_map.dart
+++ b/packages/flame_tiled/lib/src/renderable_tile_map.dart
@@ -184,6 +184,7 @@ class RenderableTiledMap {
               offset: Vector2(tx * size.x, ty * size.y)
                 ..add(layerOffset * size.x / src.width),
               rotation: flips.angle * math.pi / 2,
+              anchor: Vector2.all(0.5),
               scale: size.x / src.width,
             );
           }

--- a/packages/flame_tiled/lib/src/renderable_tile_map.dart
+++ b/packages/flame_tiled/lib/src/renderable_tile_map.dart
@@ -184,7 +184,7 @@ class RenderableTiledMap {
               offset: Vector2(tx * size.x, ty * size.y)
                 ..add(layerOffset * size.x / src.width),
               rotation: flips.angle * math.pi / 2,
-              anchor: Vector2(size.x / 2, size.y / 2),
+              anchor: Vector2(src.width / 2, src.height / 2),
               scale: size.x / src.width,
             );
           }

--- a/packages/flame_tiled/lib/src/renderable_tile_map.dart
+++ b/packages/flame_tiled/lib/src/renderable_tile_map.dart
@@ -184,7 +184,7 @@ class RenderableTiledMap {
               offset: Vector2(tx * size.x, ty * size.y)
                 ..add(layerOffset * size.x / src.width),
               rotation: flips.angle * math.pi / 2,
-              anchor: Vector2.all(0.5),
+              anchor: Vector2(size.x / 2, size.y / 2),
               scale: size.x / src.width,
             );
           }


### PR DESCRIPTION
fix: add centered anchor for rotations

# Description

Fix for tile rotations moving tiles into the wrong positions by rotating around the wrong anchor point.

## Checklist

<!-- Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes (`[x]`). This will ensure a smooth and quick review process. -->

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [ ] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `examples`.

## Breaking Change

<!-- Does your PR require Flame users to manually update their apps to accommodate your change? 

If the PR is a breaking change this should be indicated with suffix "!"  (for example, `feat!:`, `fix!:`). See [Conventional Commit] for details.
-->

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

## Related Issues

<!-- Provide a list of issues related to this PR from the [issue database].
Indicate which of these issues are resolved or fixed by this PR, i.e. Fixes #xxxx* !-->

<!-- Links -->
[issue database]: https://github.com/flame-engine/flame/issues
[Contributor Guide]: https://github.com/flame-engine/flame/blob/main/CONTRIBUTING.md
[Flame Style Guide]: https://github.com/flame-engine/flame/blob/main/STYLEGUIDE.md
[Conventional Commit]: https://conventionalcommits.org
